### PR TITLE
Mirror of Kitware CMake#330

### DIFF
--- a/Modules/Internal/CPack/CPackNuGet.cmake
+++ b/Modules/Internal/CPack/CPackNuGet.cmake
@@ -276,7 +276,7 @@ function(_cpack_nuget_make_files_tag)
     set(_CPACK_NUGET_FILES_TAG "<files>\n${_files}    </files>" PARENT_SCOPE)
 endfunction()
 
-find_program(NUGET_EXECUTABLE NuGet)
+find_program(NUGET_EXECUTABLE nuget)
 _cpack_nuget_debug_var(NUGET_EXECUTABLE)
 if(NOT NUGET_EXECUTABLE)
     message(FATAL_ERROR "NuGet executable not found")


### PR DESCRIPTION
Mirror of Kitware CMake#330
There is no need to use a case sensitive executable name, since it will be handled gracefully on windows anyway. This change allow support for Linux system, in particular Debian distribution where:

```
$ dpkg -L nuget
...
/usr/bin/nuget
```

Fixes symptoms:

```
CPackNuGet:Debug: NUGET_EXECUTABLE=`NUGET_EXECUTABLE-NOTFOUND`
CMake Error at /usr/share/cmake-3.13/Modules/Internal/CPack/CPackNuGet.cmake:282 (message):
  NuGet executable not found
```

Thanks for your interest in contributing to CMake!  The GitHub repository
is a mirror provided for convenience, but CMake does not use GitHub pull
requests for contribution.  Please see

  https://gitlab.kitware.com/cmake/cmake/tree/master/CONTRIBUTING.rst

for contribution instructions.  GitHub OAuth may be used to sign in.

